### PR TITLE
Add cerebras-llama3.3-70b

### DIFF
--- a/llm_cerebras/cerebras.py
+++ b/llm_cerebras/cerebras.py
@@ -7,7 +7,10 @@ from typing import Optional, List
 @llm.hookimpl
 def register_models(register):
     for model_id in CerebrasModel.model_map.keys():
-        register(CerebrasModel(model_id))
+        aliases = tuple()
+        if model_id == "cerebras-llama3.3-70b":
+            aliases = ("cerebras-llama3.1-70b",)
+        register(CerebrasModel(model_id), aliases=aliases)
 
 class CerebrasModel(llm.Model):
     can_stream = True
@@ -16,7 +19,7 @@ class CerebrasModel(llm.Model):
 
     model_map = {
         "cerebras-llama3.1-8b": "llama3.1-8b",
-        "cerebras-llama3.1-70b": "llama3.1-70b"
+        "cerebras-llama3.3-70b": "llama-3.3-70b"
     }
 
     class Options(llm.Options):


### PR DESCRIPTION
Make `cerebras-llama3.1-70b` an alias for it, as per [Cerebras deprecation plan](https://inference-docs.cerebras.ai/introduction):

> Starting on Wednesday, December 18th, 2024, the `llama3.1-70b` model will be automatically upgraded to `llama-3.3-70b`. Any existing references to `llama3.1-70b` in your code will continue to work during a short-term aliasing period. However, we strongly encourage you to update your references to the `llama-3.3-70b` model as soon as possible, since the aliasing will not be maintained indefinitely.

Closes:
- https://github.com/irthomasthomas/llm-cerebras/issues/3