### PR TITLE
feat(models): add dynamic model fetching with caching and refresh com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,25 @@ llm keys set cerebras
 
 ## Listing available models
 
+The plugin automatically fetches the latest available models from the Cerebras API and caches them for 24 hours.
+
 ```bash
 llm models list | grep cerebras
 # CerebrasModel: cerebras-llama3.1-8b
 # CerebrasModel: cerebras-llama3.3-70b
 # CerebrasModel: cerebras-llama-4-scout-17b-16e-instruct
-# CerebrasModel: cerebras-deepseek-r1-distill-llama-70b
+# CerebrasModel: cerebras-qwen-3-32b
 ```
+
+## Refreshing models
+
+To get the latest models from the Cerebras API and update the cache:
+
+```bash
+llm cerebras refresh
+```
+
+This will fetch the current list of available models and save them to the cache. The models are automatically cached for 24 hours, so you typically don't need to refresh manually unless you want to check for newly released models.
 
 ## Schema Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-cerebras"
-version = "0.1.7"
+version = "0.1.8"
 description = "Plugin for LLM adding fast Cerebras inference API support"
 readme = "README.md"
 authors = [{name = "Thomas (Thomasthomas) Hughes"}]


### PR DESCRIPTION
…mand

- Implement automatic model fetching from Cerebras API with 24-hour cache
- Add 'llm cerebras refresh' command to manually update model list
- Replace static model map with dynamic loading from API or cache
- Add fallback to hardcoded models when API is unavailable
- Update documentation with model refresh instructions